### PR TITLE
Fix/display login conditions

### DIFF
--- a/src/microsoft/office/license/microsoft-office-license.service.js
+++ b/src/microsoft/office/license/microsoft-office-license.service.js
@@ -268,4 +268,11 @@ angular.module("Module.microsoft.services").service("MicrosoftOfficeLicenseServi
             this.$window.open(`${expressOrderUrl}#/new/express/resume?products=${JSURL.stringify(answer)}`, "_blank");
         });
     }
+
+    static getLoginConditions () {
+        return {
+            minLength: 3,
+            maxLength: 20
+        };
+    }
 });

--- a/src/microsoft/office/license/microsoft-office-license.service.js
+++ b/src/microsoft/office/license/microsoft-office-license.service.js
@@ -279,7 +279,7 @@ angular.module("Module.microsoft.services").service("MicrosoftOfficeLicenseServi
 
     getLoginConditionsMessage () {
         const conditions = this.constructor.getLoginConditions();
-        return `${this.translator.tr("microsoft_office_license_add_user_login_conditions", [conditions.minLength, conditions.maxLength])}` +
-               `${this.translator.tr("microsoft_office_license_add_user_login_condition_exception")}`;
+        return `${this.translator.tr("microsoft_office_license_add_user_login_conditions", [conditions.minLength, conditions.maxLength])}
+                ${this.translator.tr("microsoft_office_license_add_user_login_condition_exception")}`;
     }
 });

--- a/src/microsoft/office/license/microsoft-office-license.service.js
+++ b/src/microsoft/office/license/microsoft-office-license.service.js
@@ -276,4 +276,10 @@ angular.module("Module.microsoft.services").service("MicrosoftOfficeLicenseServi
             loginPattern: /^(?!\.)(?:[-!#$%&'\^_`{}~A-Za-z\d]|\.(?!\.))+(?!\.)$/
         };
     }
+
+    getLoginConditionsMessage () {
+        const conditions = this.constructor.getLoginConditions();
+        return `${this.translator.tr("microsoft_office_license_add_user_login_conditions", [conditions.minLength, conditions.maxLength])}` +
+               `${this.translator.tr("microsoft_office_license_add_user_login_condition_exception")}`;
+    }
 });

--- a/src/microsoft/office/license/microsoft-office-license.service.js
+++ b/src/microsoft/office/license/microsoft-office-license.service.js
@@ -272,7 +272,8 @@ angular.module("Module.microsoft.services").service("MicrosoftOfficeLicenseServi
     static getLoginConditions () {
         return {
             minLength: 3,
-            maxLength: 20
+            maxLength: 20,
+            loginPattern: /^(?!\.)(?:[-!#$%&'\^_`{}~A-Za-z\d]|\.(?!\.))+(?!\.)$/
         };
     }
 });

--- a/src/microsoft/office/license/user/add/microsoft-office-license-user-add.controller.js
+++ b/src/microsoft/office/license/user/add/microsoft-office-license-user-add.controller.js
@@ -19,6 +19,7 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
             userAdd: false
         };
         this.conditions = this.licenseService.constructor.getLoginConditions();
+        this.conditionsMessage = this.licenseService.getLoginConditionsMessage();
 
         this.$scope.addUser = () => {
             this.loaders.userAdd = true;

--- a/src/microsoft/office/license/user/add/microsoft-office-license-user-add.controller.js
+++ b/src/microsoft/office/license/user/add/microsoft-office-license-user-add.controller.js
@@ -18,7 +18,7 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
             licenseEnum: false,
             userAdd: false
         };
-        this.validationLoginPattern = /^(?!\.)(?:[-!#$%&'\^_`{}~A-Za-z\d]|\.(?!\.))+(?!\.)$/;
+        this.conditions = this.licenseService.constructor.getLoginConditions();
 
         this.$scope.addUser = () => {
             this.loaders.userAdd = true;

--- a/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
+++ b/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
@@ -46,12 +46,20 @@
                     <label class="control-label col-md-4 required" for="login"
                            data-i18n-static="microsoft_office_license_add_user_login_label"></label>
                     <div class="col-md-6">
-                        <input type="text" class="form-control" id="login" name="login" required
-                               data-ng-minLength="addUserCtrl.conditions.minLength"
-                               data-ng-maxLength="addUserCtrl.conditions.maxLength"
-                               data-ng-model="addUserCtrl.user.login"
-                               data-ng-pattern="addUserCtrl.conditions.loginPattern"
-                               data-ng-trim="true">
+                        <div class="input-group">
+                            <input type="text" class="form-control" id="login" name="login" required
+                                   data-ng-minLength="addUserCtrl.conditions.minLength"
+                                   data-ng-maxLength="addUserCtrl.conditions.maxLength"
+                                   data-ng-model="addUserCtrl.user.login"
+                                   data-ng-pattern="addUserCtrl.conditions.loginPattern"
+                                   data-ng-trim="true">
+                            <span class="input-group-addon"
+                                  data-uib-tooltip="{{::addUserCtrl.conditionsMessage}}"
+                                  data-tooltip-placement="right"
+                                  data-tooltip-append-to-body="true">
+                                <span class="oui-icon oui-icon-help_circle oui-icon_small" aria-hidden="true"></span>
+                             </span>
+                        </div>
                         <div data-ng-if="microsoftOfficeLicenseAddUserForm.login.$dirty">
                             <small class="help-block"
                                    data-i18n-static="microsoft_office_license_add_user_required"
@@ -87,10 +95,6 @@
                                data-ng-if="microsoftOfficeLicenseAddUserForm.licence.$dirty && microsoftOfficeLicenseAddUserForm.licence.$invalid">
                         </small>
                     </div>
-                </div>
-
-                <div class="alert alert-info mb-5" role="alert"
-                     data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions',[addUserCtrl.conditions.minLength,addUserCtrl.conditions.maxLength])">
                 </div>
             </form>
         </div>

--- a/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
+++ b/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
@@ -56,6 +56,7 @@
                             <span class="input-group-addon"
                                   data-uib-tooltip="{{::addUserCtrl.conditionsMessage}}"
                                   data-tooltip-placement="right"
+                                  data-tooltip-class="pre-line"
                                   data-tooltip-append-to-body="true">
                                 <span class="oui-icon oui-icon-help_circle oui-icon_small" aria-hidden="true"></span>
                              </span>

--- a/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
+++ b/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
@@ -47,10 +47,10 @@
                            data-i18n-static="microsoft_office_license_add_user_login_label"></label>
                     <div class="col-md-6">
                         <input type="text" class="form-control" id="login" name="login" required
-                               data-ng-minLength="3"
-                               data-ng-maxLength="20"
+                               data-ng-minLength="addUserCtrl.conditions.minLength"
+                               data-ng-maxLength="addUserCtrl.conditions.maxLength"
                                data-ng-model="addUserCtrl.user.login"
-                               data-ng-pattern="validationLoginPattern"
+                               data-ng-pattern="addUserCtrl.conditions.loginPattern"
                                data-ng-trim="true">
                         <div data-ng-if="microsoftOfficeLicenseAddUserForm.login.$dirty">
                             <small class="help-block"
@@ -58,11 +58,11 @@
                                    data-ng-if="microsoftOfficeLicenseAddUserForm.login.$error.required">
                             </small>
                             <small class="help-block"
-                                   data-ng-bind-html="tr('microsoft_office_license_add_user_login_minlength',[3])"
+                                   data-ng-bind-html="tr('microsoft_office_license_add_user_login_minlength',[addUserCtrl.conditions.minLength])"
                                    data-ng-if="microsoftOfficeLicenseAddUserForm.login.$error.minlength">
                             </small>
                             <small class="help-block"
-                                   data-ng-bind-html="tr('microsoft_office_license_add_user_login_maxlength', [20])"
+                                   data-ng-bind-html="tr('microsoft_office_license_add_user_login_maxlength', [addUserCtrl.conditions.maxLength])"
                                    data-ng-if="microsoftOfficeLicenseAddUserForm.login.$error.maxlength">
                             </small>
                         </div>

--- a/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
+++ b/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
@@ -88,6 +88,10 @@
                         </small>
                     </div>
                 </div>
+
+                <div class="alert alert-info mb-5" role="alert"
+                     data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions',[addUserCtrl.conditions.minLength,addUserCtrl.conditions.maxLength])">
+                </div>
             </form>
         </div>
 

--- a/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
+++ b/src/microsoft/office/license/user/add/microsoft-office-license-user-add.html
@@ -58,11 +58,11 @@
                                    data-ng-if="microsoftOfficeLicenseAddUserForm.login.$error.required">
                             </small>
                             <small class="help-block"
-                                   data-i18n-static="microsoft_office_license_add_user_login_minlength"
+                                   data-ng-bind-html="tr('microsoft_office_license_add_user_login_minlength',[3])"
                                    data-ng-if="microsoftOfficeLicenseAddUserForm.login.$error.minlength">
                             </small>
                             <small class="help-block"
-                                   data-i18n-static="microsoft_office_license_add_user_login_maxlength"
+                                   data-ng-bind-html="tr('microsoft_office_license_add_user_login_maxlength', [20])"
                                    data-ng-if="microsoftOfficeLicenseAddUserForm.login.$error.maxlength">
                             </small>
                         </div>

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.controller.js
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.controller.js
@@ -13,6 +13,7 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
         };
 
         this.conditions = this.microsoftOfficeLicenseService.constructor.getLoginConditions();
+        this.conditionsMessage = this.microsoftOfficeLicenseService.getLoginConditionsMessage();
         this.user = angular.copy(this.$scope.currentActionData.user);
 
         if (!_.isEmpty(this.user.activationEmail)) {

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.controller.js
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.controller.js
@@ -8,8 +8,6 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
     }
 
     $onInit () {
-        this.loginPattern = /^(?!\.)(?:[-!#$%&'\^_`{}~A-Za-z\d]|\.(?!\.))+(?!\.)$/;
-
         this.loaders = {
             userEdit: false
         };

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.controller.js
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.controller.js
@@ -14,6 +14,7 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
             userEdit: false
         };
 
+        this.conditions = this.microsoftOfficeLicenseService.constructor.getLoginConditions();
         this.user = angular.copy(this.$scope.currentActionData.user);
 
         if (!_.isEmpty(this.user.activationEmail)) {

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -46,13 +46,21 @@
                     <label class="control-label col-md-4 required" for="login"
                            data-i18n-static="microsoft_office_license_add_user_login_label"></label>
                     <div class="col-md-6">
-                        <input type="text" class="form-control" id="login" name="login" required
-                               data-ng-minLength="updateUserCtrl.conditions.minLength"
-                               data-ng-maxLength="updateUserCtrl.conditions.maxLength"
-                               data-ng-model="updateUserCtrl.user.login"
-                               data-ng-model-options="{updateOn: 'blur'}"
-                               data-ng-pattern="updateUserCtrl.conditions.loginPattern"
-                               data-ng-trim="true">
+                        <div class="input-group">
+                            <input type="text" class="form-control" id="login" name="login" required
+                                   data-ng-minLength="updateUserCtrl.conditions.minLength"
+                                   data-ng-maxLength="updateUserCtrl.conditions.maxLength"
+                                   data-ng-model="updateUserCtrl.user.login"
+                                   data-ng-model-options="{updateOn: 'blur'}"
+                                   data-ng-pattern="updateUserCtrl.conditions.loginPattern"
+                                   data-ng-trim="true">
+                            <span class="input-group-addon"
+                                  data-uib-tooltip="{{::updateUserCtrl.conditionsMessage}}"
+                                  data-tooltip-placement="right"
+                                  data-tooltip-append-to-body="true">
+                                <span class="oui-icon oui-icon-help_circle oui-icon_small" aria-hidden="true"></span>
+                            </span>
+                        </div>
                         <div data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$dirty"
                              data-ng-messages="microsoftOfficeLicenseUserUpdateForm.login.$error">
                             <small class="help-block"
@@ -73,11 +81,6 @@
                             </small>
                         </div>
                     </div>
-                </div>
-
-                <div class="alert alert-info" role="alert">
-                    <p data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions', [updateUserCtrl.conditions.minLength, updateUserCtrl.conditions.maxLength])"></p>
-                    <p data-i18n-static="microsoft_office_license_add_user_login_condition_exception"></p>
                 </div>
             </form>
         </div>

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -53,18 +53,23 @@
                                data-ng-model-options="{updateOn: 'blur'}"
                                data-ng-pattern="updateUserCtrl.conditions.loginPattern"
                                data-ng-trim="true">
-                        <div data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$dirty">
+                        <div data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$dirty"
+                             data-ng-messages="microsoftOfficeLicenseUserUpdateForm.login.$error">
                             <small class="help-block"
                                    data-i18n-static="microsoft_office_license_add_user_required"
-                                   data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$error.required">
+                                   data-ng-message="required">
                             </small>
                             <small class="help-block"
                                    data-ng-bind-html="tr('microsoft_office_license_add_user_login_minlength', [updateUserCtrl.conditions.minLength])"
-                                   data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$error.minlength">
+                                   data-ng-message="minlength">
                             </small>
                             <small class="help-block"
                                    data-ng-bind-html="tr('microsoft_office_license_add_user_login_maxlength', [updateUserCtrl.conditions.maxLength])"
-                                   data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$error.maxlength">
+                                   data-ng-message="maxlength">
+                            </small>
+                            <small class="help-block"
+                                   data-i18n-static="microsoft_office_license_add_user_login_invalid_pattern"
+                                   data-ng-message="pattern">
                             </small>
                         </div>
                     </div>

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -57,6 +57,7 @@
                             <span class="input-group-addon"
                                   data-uib-tooltip="{{::updateUserCtrl.conditionsMessage}}"
                                   data-tooltip-placement="right"
+                                  data-tooltip-class="pre-line"
                                   data-tooltip-append-to-body="true">
                                 <span class="oui-icon oui-icon-help_circle oui-icon_small" aria-hidden="true"></span>
                             </span>

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -69,6 +69,11 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="alert alert-info mb-5" role="alert"
+                     data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions',[updateUserCtrl.conditions.minLength,updateUserCtrl.conditions.maxLength])">
+
+                </div>
             </form>
         </div>
 

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -75,8 +75,9 @@
                     </div>
                 </div>
 
-                <div class="alert alert-info mb-5" role="alert"
-                     data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions', [updateUserCtrl.conditions.minLength, updateUserCtrl.conditions.maxLength])">
+                <div class="alert alert-info" role="alert">
+                    <p data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions', [updateUserCtrl.conditions.minLength, updateUserCtrl.conditions.maxLength])"></p>
+                    <p data-i18n-static="microsoft_office_license_add_user_login_condition_exception"></p>
                 </div>
             </form>
         </div>

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -42,8 +42,7 @@
 
                 <div class="form-group"
                      data-ng-class="{
-                         'has-error': microsoftOfficeLicenseUserUpdateForm.login.$dirty && microsoftOfficeLicenseUserUpdateForm.login.$invalid,
-                         'has-success': microsoftOfficeLicenseUserUpdateForm.login.$dirty && microsoftOfficeLicenseUserUpdateForm.login.$valid}">
+                         'has-error': microsoftOfficeLicenseUserUpdateForm.login.$dirty && microsoftOfficeLicenseUserUpdateForm.login.$invalid}">
                     <label class="control-label col-md-4 required" for="login"
                            data-i18n-static="microsoft_office_license_add_user_login_label"></label>
                     <div class="col-md-6">
@@ -51,6 +50,7 @@
                                data-ng-minLength="updateUserCtrl.conditions.minLength"
                                data-ng-maxLength="updateUserCtrl.conditions.maxLength"
                                data-ng-model="updateUserCtrl.user.login"
+                               data-ng-model-options="{updateOn: 'blur'}"
                                data-ng-pattern="updateUserCtrl.conditions.loginPattern"
                                data-ng-trim="true">
                         <div data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$dirty">

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -71,7 +71,7 @@
                 </div>
 
                 <div class="alert alert-info mb-5" role="alert"
-                     data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions',[updateUserCtrl.conditions.minLength,updateUserCtrl.conditions.maxLength])">
+                     data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions', [updateUserCtrl.conditions.minLength, updateUserCtrl.conditions.maxLength])">
                 </div>
             </form>
         </div>

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -63,7 +63,7 @@
                                    data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$error.minlength">
                             </small>
                             <small class="help-block"
-                                   data-ng-bind-html="tr(microsoft_office_license_add_user_login_maxlength, [updateUserCtrl.conditions.maxLength])"
+                                   data-ng-bind-html="tr('microsoft_office_license_add_user_login_maxlength', [updateUserCtrl.conditions.maxLength])"
                                    data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$error.maxlength">
                             </small>
                         </div>

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -51,7 +51,7 @@
                                data-ng-minLength="updateUserCtrl.conditions.minLength"
                                data-ng-maxLength="updateUserCtrl.conditions.maxLength"
                                data-ng-model="updateUserCtrl.user.login"
-                               data-ng-pattern="updateUserCtrl.loginPattern"
+                               data-ng-pattern="updateUserCtrl.conditions.loginPattern"
                                data-ng-trim="true">
                         <div data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$dirty">
                             <small class="help-block"

--- a/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
+++ b/src/microsoft/office/license/user/update/microsoft-office-license-user-update.html
@@ -48,8 +48,8 @@
                            data-i18n-static="microsoft_office_license_add_user_login_label"></label>
                     <div class="col-md-6">
                         <input type="text" class="form-control" id="login" name="login" required
-                               data-ng-minLength="3"
-                               data-ng-maxLength="20"
+                               data-ng-minLength="updateUserCtrl.conditions.minLength"
+                               data-ng-maxLength="updateUserCtrl.conditions.maxLength"
                                data-ng-model="updateUserCtrl.user.login"
                                data-ng-pattern="updateUserCtrl.loginPattern"
                                data-ng-trim="true">
@@ -59,11 +59,11 @@
                                    data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$error.required">
                             </small>
                             <small class="help-block"
-                                   data-i18n-static="microsoft_office_license_add_user_login_minlength"
+                                   data-ng-bind-html="tr('microsoft_office_license_add_user_login_minlength', [updateUserCtrl.conditions.minLength])"
                                    data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$error.minlength">
                             </small>
                             <small class="help-block"
-                                   data-i18n-static="microsoft_office_license_add_user_login_maxlength"
+                                   data-ng-bind-html="tr(microsoft_office_license_add_user_login_maxlength, [updateUserCtrl.conditions.maxLength])"
                                    data-ng-if="microsoftOfficeLicenseUserUpdateForm.login.$error.maxlength">
                             </small>
                         </div>
@@ -72,7 +72,6 @@
 
                 <div class="alert alert-info mb-5" role="alert"
                      data-ng-bind-html="tr('microsoft_office_license_add_user_login_conditions',[updateUserCtrl.conditions.minLength,updateUserCtrl.conditions.maxLength])">
-
                 </div>
             </form>
         </div>

--- a/src/resources/i18n/microsoft/Messages_fr_FR.xml
+++ b/src/resources/i18n/microsoft/Messages_fr_FR.xml
@@ -88,8 +88,8 @@
    <translation id="microsoft_office_license_add_user_license_none" qtlid="446611">Sélectionnez une licence</translation>
    <translation id="microsoft_office_license_detail_user_add_error" qtlid="264940">Une erreur est survenue lors de l'ajout de l'utilisateur</translation>
    <translation id="microsoft_office_license_add_user_login_conditions">Attention, le login doit respecter les conditions suivantes : <ul><li>Minimum {0} caractères</li><li>Maximum {1} caractères</li><li>Doit être composé de chiffres et de lettres</li><li>Peut contenir les caractères : - _ . ! # $ % & ' ^ ` { } ~</li></ul></translation>
-   <translation id="microsoft_office_license_add_user_login_minlength" qtlid="264953">Le nom d'utilisateur doit contenir au minimum 3 caractères</translation>
-   <translation id="microsoft_office_license_add_user_login_maxlength" qtlid="264966">Le nom d'utilisateur est limité à 20 caractères maximum</translation>
+   <translation id="microsoft_office_license_add_user_login_minlength" qtlid="264953">Le nom d'utilisateur doit contenir au minimum {0} caractères</translation>
+   <translation id="microsoft_office_license_add_user_login_maxlength" qtlid="264966">Le nom d'utilisateur est limité à {0} caractères maximum</translation>
    <translation id="microsoft_office_license_add_user_field_required" qtlid="404590">Les champs marqués d'une {0} sont obligatoires.</translation>
 
    <translation id="microsoft_office_license_order_user_price_warning" qtlid="446624">En validant, vous serez redirigé vers le bon de commande. Revenez ici une fois le payement effectué pour configurer vos nouveaux utilisateurs.</translation>

--- a/src/resources/i18n/microsoft/Messages_fr_FR.xml
+++ b/src/resources/i18n/microsoft/Messages_fr_FR.xml
@@ -89,8 +89,8 @@
    <translation id="microsoft_office_license_detail_user_add_error" qtlid="264940">Une erreur est survenue lors de l'ajout de l'utilisateur</translation>
    <translation id="microsoft_office_license_add_user_login_conditions">Attention, le login doit respecter les conditions suivantes : <ul><li>Minimum {0} caractères</li><li>Maximum {1} caractères</li><li>Peut contenir des lettres, des chiffres et les caractères suivants - _ ! # $ % & ' ^ ` { } ~</li><li>Peut contenir le caractère "." s'il est précédé d'un autre caractère autorisé et n'est pas suivi d'un autre "."</li></ul></translation>
    <translation id="microsoft_office_license_add_user_login_invalid_pattern">Le nom d'utilisateur contient des caractères non autorisés</translation>
-   <translation id="microsoft_office_license_add_user_login_minlength" qtlid="264953">Le nom d'utilisateur doit contenir au minimum {0} caractères</translation>
-   <translation id="microsoft_office_license_add_user_login_maxlength" qtlid="264966">Le nom d'utilisateur est limité à {0} caractères maximum</translation>
+   <translation id="microsoft_office_license_add_user_login_minlength">Le nom d'utilisateur doit contenir au minimum {0} caractères</translation>
+   <translation id="microsoft_office_license_add_user_login_maxlength">Le nom d'utilisateur est limité à {0} caractères maximum</translation>
    <translation id="microsoft_office_license_add_user_field_required" qtlid="404590">Les champs marqués d'une {0} sont obligatoires.</translation>
 
    <translation id="microsoft_office_license_order_user_price_warning" qtlid="446624">En validant, vous serez redirigé vers le bon de commande. Revenez ici une fois le payement effectué pour configurer vos nouveaux utilisateurs.</translation>

--- a/src/resources/i18n/microsoft/Messages_fr_FR.xml
+++ b/src/resources/i18n/microsoft/Messages_fr_FR.xml
@@ -87,6 +87,7 @@
    <translation id="microsoft_office_license_add_user_confirm" qtlid="264914">L'utilisateur suivant sera ajouté</translation>
    <translation id="microsoft_office_license_add_user_license_none" qtlid="446611">Sélectionnez une licence</translation>
    <translation id="microsoft_office_license_detail_user_add_error" qtlid="264940">Une erreur est survenue lors de l'ajout de l'utilisateur</translation>
+   <translation id="microsoft_office_license_add_user_login_conditions">Attention, le login doit respecter les conditions suivantes : <ul><li>Minimum {0} caractères</li><li>Maximum {1} caractères</li><li>Doit être composé de chiffres et de lettres</li><li>Peut contenir les caractères : - _ . ! # $ % & ' ^ ` { } ~</li></ul></translation>
    <translation id="microsoft_office_license_add_user_login_minlength" qtlid="264953">Le nom d'utilisateur doit contenir au minimum 3 caractères</translation>
    <translation id="microsoft_office_license_add_user_login_maxlength" qtlid="264966">Le nom d'utilisateur est limité à 20 caractères maximum</translation>
    <translation id="microsoft_office_license_add_user_field_required" qtlid="404590">Les champs marqués d'une {0} sont obligatoires.</translation>

--- a/src/resources/i18n/microsoft/Messages_fr_FR.xml
+++ b/src/resources/i18n/microsoft/Messages_fr_FR.xml
@@ -87,7 +87,7 @@
    <translation id="microsoft_office_license_add_user_confirm" qtlid="264914">L'utilisateur suivant sera ajouté</translation>
    <translation id="microsoft_office_license_add_user_license_none" qtlid="446611">Sélectionnez une licence</translation>
    <translation id="microsoft_office_license_detail_user_add_error" qtlid="264940">Une erreur est survenue lors de l'ajout de l'utilisateur</translation>
-   <translation id="microsoft_office_license_add_user_login_conditions">Attention, le login doit respecter les conditions suivantes : <ul><li>Minimum {0} caractères</li><li>Maximum {1} caractères</li><li>Doit être composé de chiffres et de lettres</li><li>Peut contenir les caractères : - _ . ! # $ % & ' ^ ` { } ~</li></ul></translation>
+   <translation id="microsoft_office_license_add_user_login_conditions">Attention, le login doit respecter les conditions suivantes : <ul><li>Minimum {0} caractères</li><li>Maximum {1} caractères</li><li>Peut contenir des lettres, des chiffres et les caractères suivants - _ ! # $ % & ' ^ ` { } ~</li><li>Peut contenir le caractère "." s'il est précédé d'un autre caractère autorisé et n'est pas suivi d'un autre "."</li></ul></translation>
    <translation id="microsoft_office_license_add_user_login_minlength" qtlid="264953">Le nom d'utilisateur doit contenir au minimum {0} caractères</translation>
    <translation id="microsoft_office_license_add_user_login_maxlength" qtlid="264966">Le nom d'utilisateur est limité à {0} caractères maximum</translation>
    <translation id="microsoft_office_license_add_user_field_required" qtlid="404590">Les champs marqués d'une {0} sont obligatoires.</translation>

--- a/src/resources/i18n/microsoft/Messages_fr_FR.xml
+++ b/src/resources/i18n/microsoft/Messages_fr_FR.xml
@@ -87,7 +87,8 @@
    <translation id="microsoft_office_license_add_user_confirm" qtlid="264914">L'utilisateur suivant sera ajouté</translation>
    <translation id="microsoft_office_license_add_user_license_none" qtlid="446611">Sélectionnez une licence</translation>
    <translation id="microsoft_office_license_detail_user_add_error" qtlid="264940">Une erreur est survenue lors de l'ajout de l'utilisateur</translation>
-   <translation id="microsoft_office_license_add_user_login_conditions">Attention, le login doit respecter les conditions suivantes : <ul><li>Minimum {0} caractères</li><li>Maximum {1} caractères</li><li>Peut contenir des lettres, des chiffres et les caractères suivants - _ ! # $ % & ' ^ ` { } ~</li><li>Peut contenir le caractère "." s'il est précédé d'un autre caractère autorisé et n'est pas suivi d'un autre "."</li></ul></translation>
+   <translation id="microsoft_office_license_add_user_login_conditions">Votre login doit contenir entre 3 et 20 caractères maximum. Il peut inclure des chiffres, des lettres et les caractères suivants : - _ ! # $ % & ' ^ ` { }</translation>
+   <translation id="microsoft_office_license_add_user_login_condition_exception">Il peut également contenir des points, à condition qu’ils soient précédés d'un caractère autorisé et qu'ils ne soient pas suivis d’un autre point.</translation>
    <translation id="microsoft_office_license_add_user_login_invalid_pattern">Le nom d'utilisateur contient des caractères non autorisés</translation>
    <translation id="microsoft_office_license_add_user_login_minlength">Le nom d'utilisateur doit contenir au minimum {0} caractères</translation>
    <translation id="microsoft_office_license_add_user_login_maxlength">Le nom d'utilisateur est limité à {0} caractères maximum</translation>

--- a/src/resources/i18n/microsoft/Messages_fr_FR.xml
+++ b/src/resources/i18n/microsoft/Messages_fr_FR.xml
@@ -88,6 +88,7 @@
    <translation id="microsoft_office_license_add_user_license_none" qtlid="446611">Sélectionnez une licence</translation>
    <translation id="microsoft_office_license_detail_user_add_error" qtlid="264940">Une erreur est survenue lors de l'ajout de l'utilisateur</translation>
    <translation id="microsoft_office_license_add_user_login_conditions">Attention, le login doit respecter les conditions suivantes : <ul><li>Minimum {0} caractères</li><li>Maximum {1} caractères</li><li>Peut contenir des lettres, des chiffres et les caractères suivants - _ ! # $ % & ' ^ ` { } ~</li><li>Peut contenir le caractère "." s'il est précédé d'un autre caractère autorisé et n'est pas suivi d'un autre "."</li></ul></translation>
+   <translation id="microsoft_office_license_add_user_login_invalid_pattern">Le nom d'utilisateur contient des caractères non autorisés</translation>
    <translation id="microsoft_office_license_add_user_login_minlength" qtlid="264953">Le nom d'utilisateur doit contenir au minimum {0} caractères</translation>
    <translation id="microsoft_office_license_add_user_login_maxlength" qtlid="264966">Le nom d'utilisateur est limité à {0} caractères maximum</translation>
    <translation id="microsoft_office_license_add_user_field_required" qtlid="404590">Les champs marqués d'une {0} sont obligatoires.</translation>


### PR DESCRIPTION
## Display conditions for a valid login when adding or editing a user


### Description of the Change

Before: No indication was given concerning the allowed characters in login
Now: An information alert is displayed explaining the allowed characters
