### PR TITLE
Fix/license display progress

### DIFF
--- a/src/microsoft/office/license/microsoft-office-license.service.js
+++ b/src/microsoft/office/license/microsoft-office-license.service.js
@@ -116,7 +116,8 @@ angular.module("Module.microsoft.services").service("MicrosoftOfficeLicenseServi
         return this.pollService.poll(`${this.basePath}/${licenseId}/user/${userId}`, null, {
             scope: $scope.$id,
             successRule: {
-                status: "ok"
+                status: "ok",
+                taskPendingId: 0
             },
             namespace
         });

--- a/src/microsoft/office/license/user/USER.html
+++ b/src/microsoft/office/license/user/USER.html
@@ -1,7 +1,7 @@
 <div class="container-fluid px-0" data-ng-controller="MicrosoftOfficeLicenseUsersCtrl as usersCtrl">
     <div class="row">
         <div class="col-md-9">
-            <div data-ovh-alert="{{alerts.main}}"></div>
+            <div data-ovh-alert="{{alerts.main}}" id="action-alert"></div>
 
             <p>
                 <span class="fa fa-download mr-2" aria-hidden="true"></span>

--- a/src/microsoft/office/license/user/USER.html
+++ b/src/microsoft/office/license/user/USER.html
@@ -32,7 +32,7 @@
                           data-ng-bind-html="$row.taskPendingId ? tr('microsoft_office_license_user_status_creating') : tr('microsoft_office_license_detail_user_not_configure')">
                     </span>
                 </oui-column>
-                <oui-action-menu data-align="end" data-compact data-ng-hide="$row.isLoading">
+                <oui-action-menu data-align="end" data-compact data-ng-if="!$row.isLoading">
                     <oui-action-menu-item data-text="{{tr('microsoft_office_license_user_change_password')}}"
                                           data-on-click="setAction('edit/password/microsoft-office-edit-password', {'user': $row, 'licenseId': currentLicense, 'license': $row.license})"
                                           data-ng-if="!$row.isVirtual"></oui-action-menu-item>

--- a/src/microsoft/office/license/user/USER.html
+++ b/src/microsoft/office/license/user/USER.html
@@ -18,7 +18,7 @@
                 <oui-column data-title="tr('microsoft_office_license_detail_user_licenses')" data-property="licences">
                     <span data-ng-repeat="licence in $row.licences track by $index" data-ng-bind="licence"></span>
                 </oui-column>
-                <oui-column data-title="tr('microsoft_office_license_detail_user_status')" data-property="">
+                <oui-column data-title="tr('microsoft_office_license_detail_user_status')">
                     <span class="label"
                           data-ng-if="!$row.isVirtual && $row.status"
                           data-ng-bind="tr('microsoft_office_license_user_status_' + $row.status)"
@@ -29,7 +29,7 @@
                     </span>
                     <span class="label label-info"
                           data-ng-if="$row.isVirtual"
-                          data-i18n-static="microsoft_office_license_detail_user_not_configure">
+                          data-ng-bind-html="$row.taskPendingId ? tr('microsoft_office_license_user_status_creating') : tr('microsoft_office_license_detail_user_not_configure')">
                     </span>
                 </oui-column>
                 <oui-action-menu data-align="end" data-compact data-ng-hide="$row.isLoading">

--- a/src/microsoft/office/license/user/microsoft-office-license-user.controller.js
+++ b/src/microsoft/office/license/user/microsoft-office-license-user.controller.js
@@ -19,7 +19,7 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
     transformItem ({ id }) {
         return this.license.getUserDetails(this.$scope.currentLicense, id)
             .then((details) => {
-                if (details.status !== "ok" || (details.isVirtual && details.taskPendingId)) {
+                if (details.taskPendingId) {
                     details.isLoading = true;
                     this.license.pollUserDetails(this.$scope.currentLicense, id, this.$scope)
                         .then(() => this.delayedGetUsers())

--- a/src/microsoft/office/license/user/microsoft-office-license-user.controller.js
+++ b/src/microsoft/office/license/user/microsoft-office-license-user.controller.js
@@ -9,9 +9,9 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
     }
 
     $onInit () {
-        this.$scope.$on("microsoft.office.license.user.add", () => this.delayedGetUsers());
-        this.$scope.$on("microsoft.office.license.user.edit", () => this.delayedGetUsers());
-        this.$scope.$on("microsoft.office.license.user.delete", () => this.delayedGetUsers());
+        this.$scope.$on("microsoft.office.license.user.add", () => this.refreshUsers());
+        this.$scope.$on("microsoft.office.license.user.edit", () => this.refreshUsers());
+        this.$scope.$on("microsoft.office.license.user.delete", () => this.refreshUsers());
 
         this.getUserIds();
     }
@@ -44,5 +44,14 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
 
     delayedGetUsers () {
         return this.$timeout(() => this.getUserIds(), 250);
+    }
+
+    scrollToAlert () {
+        this.$timeout(() => document.getElementById("action-alert").scrollIntoView(false));
+    }
+
+    refreshUsers () {
+        this.delayedGetUsers();
+        this.scrollToAlert();
     }
 });

--- a/src/microsoft/office/license/user/microsoft-office-license-user.controller.js
+++ b/src/microsoft/office/license/user/microsoft-office-license-user.controller.js
@@ -19,7 +19,7 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
     transformItem ({ id }) {
         return this.license.getUserDetails(this.$scope.currentLicense, id)
             .then((details) => {
-                if (details.status !== "ok") {
+                if (details.status !== "ok" || (details.isVirtual && details.taskPendingId)) {
                     details.isLoading = true;
                     this.license.pollUserDetails(this.$scope.currentLicense, id, this.$scope)
                         .then(() => this.delayedGetUsers())
@@ -33,7 +33,6 @@ angular.module("Module.microsoft.controllers").controller("MicrosoftOfficeLicens
                 status: "error"
             }));
     }
-
 
     getUserIds () {
         this.users = null;


### PR DESCRIPTION
## Display license progress for newly configured account 

### Description of the Change

Before: Actions progress was only shown for already configured account 
Now: Progress is displayed for newly configured account and focus is given to the created message alert 