### PR TITLE
fix(user): edit user while update in progress

### DIFF
--- a/src/microsoft/office/license/user/USER.html
+++ b/src/microsoft/office/license/user/USER.html
@@ -25,7 +25,7 @@
                           data-ng-class="{
                             'oui-status_success': $row.status === 'ok',
                             'oui-status_error': $row.status === 'deleting' || $row.status === 'error',
-                            'oui-status_info': $row.status === 'creating'}">
+                            'oui-status_info': $row.status === 'creating' || $row.status === 'updating'}">
                     </span>
                     <span class="oui-status oui-status_info"
                           data-ng-if="$row.isVirtual"

--- a/src/microsoft/office/license/user/microsoft-office-license-user.controller.js
+++ b/src/microsoft/office/license/user/microsoft-office-license-user.controller.js
@@ -20,6 +20,7 @@ angular.module('Module.microsoft.controllers').controller('MicrosoftOfficeLicens
       .then((details) => {
         if (details.taskPendingId) {
           _.set(details, 'isLoading', true);
+          _.set(details, 'status', (details.status === 'ok' ? 'updating' : details.status));
           this.license.pollUserDetails(this.$scope.currentLicense, id, this.$scope)
             .then(() => this.delayedGetUsers())
             .finally(() => { _.set(details, 'isLoading', false); });

--- a/src/microsoft/translations/Messages_fr_FR.xml
+++ b/src/microsoft/translations/Messages_fr_FR.xml
@@ -50,6 +50,7 @@
    <translation id="microsoft_office_license_detail_state_txtEntry" qtlid="264849">Entré txt</translation>
    <translation id="microsoft_office_license_detail_state_status" qtlid="26443">Statut</translation>
    <translation id="microsoft_office_license_user_status_creating" qtlid="26227">En création</translation>
+   <translation id="microsoft_office_license_user_status_updating">Mise à jour</translation>
    <translation id="microsoft_office_license_user_status_deleting" qtlid="133929">En suppression</translation>
    <translation id="microsoft_office_license_user_status_ok" qtlid="264862">Créé</translation>
    <translation id="microsoft_office_license_user_status_error" qtlid="26407">Erreur</translation>


### PR DESCRIPTION
Close MBP-49

### Requirements

When an user update is in progress, this is not indicated in the UI and the drop-down menu is invisible and this is confusing. This has to be fixed.

## UI on User Update


### Description of the Change

When an user update is in progress, this is indicated in the UI as updating. This solves the confusion.